### PR TITLE
[Rspec] Admin Borrows Controller

### DIFF
--- a/app/controllers/admin/borrows_controller.rb
+++ b/app/controllers/admin/borrows_controller.rb
@@ -63,7 +63,6 @@ class Admin::BorrowsController < Admin::BaseController
     result = @borrow.perform_action(action) ? :success : :error
 
     notify_result_to_user(action) if result == :success
-
     flash[result] = t "admin.notif.#{action}_borrow_#{result}"
     redirect_back_or_to admin_borrows_path(group:)
   end
@@ -71,6 +70,7 @@ class Admin::BorrowsController < Admin::BaseController
   def notify_result_to_user action
     link = borrow_info_path @borrow
     account = @borrow.account
+
     if %i(approve reject).include? action
       BorrowMailer.with(borrow: @borrow).notify_result.deliver_later
       account&.notification_for_me :info,

--- a/app/controllers/borrow_infos_controller.rb
+++ b/app/controllers/borrow_infos_controller.rb
@@ -86,7 +86,7 @@ class BorrowInfosController < ApplicationController
 
   def cancel_borrow_request
     if @borrow_info.perform_action :cancel
-      flash[:success] = t "cancel_request_successfully"
+      flash.now[:success] = t "cancel_request_successfully"
       redirect_to @borrow_info
     else
       flash[:danger] = t "cancel_request_failed"
@@ -96,7 +96,7 @@ class BorrowInfosController < ApplicationController
 
   def update_return_date
     if @borrow_info.perform_action :renew, borrow_info_params[:renewal_at]
-      flash[:success] = t "renew_request_successfully"
+      flash.now[:success] = t "renew_request_successfully"
       redirect_to @borrow_info
     else
       render :show, status: :bad_request

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -10,7 +10,7 @@ class Book < ApplicationRecord
   has_many :borrowings, class_name: BorrowItem.name,
                         dependent: :destroy
   has_many :borrow_requests, through: :borrowings,
-                             source: :request
+                             source: :borrow_info
   has_many :rates, class_name: BookRate.name,
                    dependent: :destroy
   has_many :raters, through: :rates

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -15,8 +15,12 @@ FactoryBot.define do
       end
     end
 
-    factory :borrowed_book do
-      borrowed_count {2}
+    trait :borrowable_book do
+      borrowed_count{1}
+    end
+
+    trait :non_borrowable_book do
+      borrowed_count{amount}
     end
   end
 end

--- a/spec/factories/borrow_infos.rb
+++ b/spec/factories/borrow_infos.rb
@@ -1,6 +1,21 @@
 FactoryBot.define do
   factory :borrow_info do
-    start_at { Date.current + 2 }
-    end_at { Date.current + 10 }
+    start_at{Faker::Date.forward(days: 5)}
+    end_at{start_at + rand(3..10)}
+    sequence(:status, (0..5).to_a.cycle){|n| n}
+    turns{status == 0 ? 0 : rand(5)}
+    renewal_at{(end_at + rand(3..10)) if status == 5}
+    account
+
+    transient do
+      borrowable{true}
+    end
+
+    after(:create) do |borrow, evaluator|
+      book_type = evaluator.borrowable ? :borrowable_book : :non_borrowable_book
+      create_list(:book, 1, book_type, borrow_requests: [borrow])
+
+      borrow.reload
+    end
   end
 end

--- a/spec/requests/admin/books_spec.rb
+++ b/spec/requests/admin/books_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe Admin::BooksController, :admin, type: :controller do
 
   describe "DELETE #destroy" do
     context "when the book has some copies borrowed" do
-      let(:book) {create(:borrowed_book)}
+      let(:book) {create(:book, :borrowable_book)}
       before do
         delete :destroy, params: {id: book.id, format: :turbo_stream}
       end

--- a/spec/requests/admin/borrows_spec.rb
+++ b/spec/requests/admin/borrows_spec.rb
@@ -1,0 +1,178 @@
+require "support/admin_shared"
+
+RSpec.describe Admin::BorrowsController, :admin, type: :controller do
+  let(:borrow){create(:borrow_info)}
+
+  shared_examples "populate borrow" do
+    it "assigns the requested borrow to @borrow" do
+      expect(assigns(:borrow)).to eq borrow
+    end
+  end
+
+  shared_examples "notifies to borrower" do |action|
+    before do
+      post action, params: {id: borrow.id, format: :turbo_stream, reject_reason: ("A Reason" if action == :reject)}
+      @last_notif = borrow.account.notifications.last
+    end
+
+    describe "creates new notification for borrower" do
+      it "with content indicate the borrow status" do
+        notif_key = {
+          approve: :approved,
+          reject: :rejected,
+          return: :returned_overdue,
+          remind: :remind
+        }[action]
+        expected = "notifications.borrow_#{notif_key}"
+        expect(@last_notif&.content).to eq expected
+      end
+
+      it "with link point to the borrow" do
+        expect(@last_notif&.link).to eq borrow_info_path(borrow)
+      end
+    end
+  end
+
+  shared_examples "change borrow status" do |action, result|
+    before do
+      @group = action == :return ? :borrowing : :pending
+      post action, params: {id: borrow.id, format: :turbo_stream, reject_reason: ("A Reason" if action == :reject)}
+    end
+
+    include_examples "set flash", result, "#{action}_borrow_#{result}"
+
+    it "redirects to borrows list page with proper group" do
+      should redirect_to admin_borrows_path(group: @group)
+    end
+  end
+
+  shared_examples "populate borrows by group" do |group|
+    context "with #{group} group" do
+      before do
+        get :index, params: {group:}
+      end
+
+      it "populates array of BorrowInfo to @borrows" do
+        expected = BorrowInfo.send(group == :pending ? :waiting : group)
+                             .includes_user.newest
+        expect(assigns(:borrows)).to match expected.to_a
+      end
+
+      it "renders :index template" do
+        should render_template :index
+      end
+    end
+  end
+
+  describe "GET #index" do
+    before do
+      create_list(:borrow_info, 6)
+    end
+
+    include_examples "populate borrows by group", :pending
+    include_examples "populate borrows by group", :history
+    include_examples "populate borrows by group", :borrowing
+  end
+
+  describe "GET #show" do
+    context "when borrow is not found" do
+      before do
+        get :show, params: {id: -1}
+      end
+      include_examples "invalid item", :borrow
+    end
+
+    context "when borrow is found" do
+      before do
+        get :show, params: {id: borrow.id}
+      end
+
+      include_examples "populate borrow"
+
+      it "populates books in this borrow request" do
+        expected = borrow.books.remain_least.with_attached_image
+        expect(assigns(:books)).to match expected.to_a
+      end
+
+      it "renders the :tab_books template" do
+        should render_template "admin/shared/tab_books"
+      end
+    end
+  end
+
+  describe "POST #approve" do
+    context "with valid borrow request" do
+      let(:borrow){create(:borrow_info, :pending)}
+
+      it_behaves_like "change borrow status", :approve, :success
+      it_behaves_like "notifies to borrower", :approve
+    end
+
+    context "with invalid borrow request" do
+      context "when borrow status is invalid for approving" do
+        let(:borrow){create(:borrow_info, :rejected)}
+        it_behaves_like "change borrow status", :approve, :error
+      end
+
+      context "when has some book that is not available" do
+        let(:borrow){create(:borrow_info, :pending, borrowable: false)}
+        it_behaves_like "change borrow status", :approve, :error
+      end
+    end
+  end
+
+  describe "POST #reject" do
+    context "with valid borrow request" do
+      let(:borrow){create(:borrow_info, :pending)}
+
+      context "and with reject reason" do
+        it_behaves_like "change borrow status", :reject, :success, {reject_reason: "Some Reason"}
+        it_behaves_like "notifies to borrower", :approve
+      end
+
+      context "and with no reject reason" do
+        before do
+          post :reject, params: {id: borrow.id, reject_reason: "", format: :turbo_stream}
+        end
+
+        include_examples "set flash", :warning, :require_reject_reason, now: true
+        it "render :notify partial" do
+          should render_template(partial: "admin/shared/_notify")
+        end
+      end
+    end
+  end
+
+  describe "POST #return" do
+    context "with valid borrow request" do
+      let(:borrow){create(:borrow_info, :approved, borrowable: true)}
+      it_behaves_like "change borrow status", :return, :success
+
+      context "when the borrow is overdue" do
+        before do
+          borrow.update_column :end_at, Time.zone.yesterday
+        end
+        it_behaves_like "notifies to borrower", :return
+      end
+    end
+
+    context "with invalid borrow request" do
+      context "when has some book that is invalid of borrowed count" do
+        it_behaves_like "change borrow status", :return, :error
+      end
+    end
+  end
+
+  describe "POST #remind" do
+    before do
+      post :remind, params: {id: borrow.id, format: :turbo_stream}
+    end
+    it_behaves_like "notifies to borrower", :remind
+
+    include_examples "set flash", :success, :send_remind_email_success, now: true
+
+    it "render :notify partial" do
+      should render_template(partial: "admin/shared/_notify")
+    end
+  end
+end

--- a/spec/requests/borrow_infos_spec.rb
+++ b/spec/requests/borrow_infos_spec.rb
@@ -101,14 +101,16 @@ RSpec.describe BorrowInfosController, type: :controller do
     end
 
     context "when status is match the case pending" do
-      before { post :handle_status_action,  params: { id: borrow_info1.id, status: "pending" } }
+      let(:borrow_info){create(:borrow_info, :pending)}
+      before { post :handle_status_action,  params: { id: borrow_info.id, status: "pending" } }
 
       it_behaves_like "displays flash message", :success, "cancel_request_successfully"
     end
 
     context "when status is match the case approved" do
+      let(:borrow_info){create(:borrow_info, :approved)}
       before do
-        patch :handle_status_action, params: { id: borrow_info1.id, status: "approved", borrow_info: { renewal_at: Date.current + 15 } }
+        patch :handle_status_action, params: { id: borrow_info.id, status: "approved", borrow_info: { renewal_at: borrow_info.end_at + 15 } }
       end
 
       context "when renew request is false" do
@@ -123,13 +125,15 @@ RSpec.describe BorrowInfosController, type: :controller do
     end
 
     context "when status is match the case renewing" do
-      before { post :handle_status_action,  params: { id: borrow_info1.id, status: "renewing" } }
+      let(:borrow_info){create(:borrow_info, :renewing)}
+      before { post :handle_status_action,  params: { id: borrow_info.id, status: "renewing" } }
 
       it_behaves_like "displays flash message", :success, "cancel_request_successfully"
     end
 
     context "when status is not match the case" do
-      before { post :handle_status_action,  params: { id: borrow_info1.id, status: "" } }
+      let(:borrow_info){create(:borrow_info)}
+      before { post :handle_status_action,  params: { id: borrow_info.id, status: "" } }
 
       it_behaves_like "displays flash message", :danger, "unknown_status_request"
     end


### PR DESCRIPTION
## Related Tickets
- [Ticket](https://edu-redmine.sun-asterisk.vn/issues/71945)

## WHAT (optional)

## HOW

## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)
![image](https://github.com/awesome-academy/HN_Ruby_Intern_2023_Library_Management/assets/84193576/9ce2c5d6-d7b8-4c9d-b25e-1b9eb102a887)


## Notes (Kiến thức tìm hiểu thêm)
